### PR TITLE
add 5 methods returning boolean

### DIFF
--- a/src/main/java/com/simsilica/mathd/Matrix3d.java
+++ b/src/main/java/com/simsilica/mathd/Matrix3d.java
@@ -93,6 +93,20 @@ public class Matrix3d implements Cloneable, java.io.Serializable {
         return this;
     }
 
+    /**
+     * Tests for identity. The matrix is unaffected.
+     *
+     * @return true if all diagonal elements are 1 and all other elements are
+     * 0 or -0, otherwise false
+     */
+    public boolean isIdentity() {
+        if( m00 == 1. && m01 == 0. && m02 == 0. && m10 == 0. && m11 == 1.
+                && m12 == 0. && m20 == 0. && m21 == 0. && m22 == 1. )
+            return true;
+        else
+            return false;
+    }
+
     public Vec3d getColumn( int i ) {
         switch( i ) {
             case 0:

--- a/src/main/java/com/simsilica/mathd/Matrix4d.java
+++ b/src/main/java/com/simsilica/mathd/Matrix4d.java
@@ -90,6 +90,22 @@ public class Matrix4d implements Cloneable, java.io.Serializable {
         m00 = m11 = m22 = m33 = 1;
     }
 
+    /**
+     * Tests for identity. The matrix is unaffected.
+     *
+     * @return true if all diagonal elements are 1 and all other elements are
+     * 0 or -0, otherwise false
+     */
+    public boolean isIdentity() {
+        if( m00 == 1. && m01 == 0. && m02 == 0. && m03 == 0. && m10 == 0.
+                && m11 == 1. && m12 == 0. && m13 == 0. && m20 == 0. && m21 == 0.
+                && m22 == 1. && m23 == 0. && m30 == 0. && m31 == 0. && m32 == 0.
+                && m33 == 1. )
+            return true;
+        else
+            return false;
+    }
+
     public void setTransform( Vec3d pos, Matrix3d rot ) {
         m00 = rot.m00;
         m01 = rot.m01;

--- a/src/main/java/com/simsilica/mathd/Quatd.java
+++ b/src/main/java/com/simsilica/mathd/Quatd.java
@@ -135,6 +135,31 @@ public final class Quatd implements Cloneable, java.io.Serializable {
         return true;
     }
 
+    /**
+     * Tests for an identity rotation. The quaternion is unaffected.
+     *
+     * @return true if W is non-zero and not NaN
+     * and X, Y, and Z are all 0 or -0, otherwise false
+     */
+    public boolean isRotationIdentity() {
+        if( x == 0. && y == 0. && z == 0. && w != 0. && !Double.isNaN(w) )
+            return true;
+        else
+            return false;
+    }
+
+    /**
+     * Tests for a zero value. The quaternion is unaffected.
+     *
+     * @return true if all components are 0 or -0, otherwise false
+     */
+    public boolean isZero() {
+        if( x == 0. && y == 0. && z == 0. && w == 0. )
+            return true;
+        else
+            return false;
+    }
+
     public final Quatd set( double x, double y, double z, double w ) {
         this.x = x;
         this.y = y;

--- a/src/main/java/com/simsilica/mathd/Vec3d.java
+++ b/src/main/java/com/simsilica/mathd/Vec3d.java
@@ -133,7 +133,21 @@ public class Vec3d implements Cloneable, java.io.Serializable {
         }
         return true;
     }
-    
+
+    /**
+     * Tests for finite components. The vector is unaffected.
+     *
+     * @return false if any component is infinite or NaN, otherwise true
+     */
+    public boolean isFinite() {
+        if( Double.isInfinite(x) || Double.isNaN(x)
+                || Double.isInfinite(y) || Double.isNaN(y)
+                || Double.isInfinite(z) || Double.isNaN(z) )
+            return false;
+        else
+            return true;
+    }
+
     public final Vec3d set( double x, double y, double z ) {
         this.x = x;
         this.y = y;


### PR DESCRIPTION
This PR adds:
+ `Matrix3d.isIdentity()`
+ `Matrix4d.isIdentity()`
+ `Quatd.isRotationIdentity()`
+ `Quatd.isZero()`
+ `Vec3d.isFinite()`

Since there are many quaternion values that represent a null rotation, it may be useful to distinguish  `isRotationIdentity()` from `isIdentity()`.

Simplification is possible with Java 1.8, which added the `Double.isFinite()` method.