### PR TITLE
add javadoc for overriding methods

### DIFF
--- a/src/main/java/com/simsilica/mathd/Matrix3d.java
+++ b/src/main/java/com/simsilica/mathd/Matrix3d.java
@@ -123,6 +123,11 @@ public class Matrix3d implements Cloneable, java.io.Serializable {
         this.m22 = m22;
     } 
  
+    /**
+     * Creates a copy of the current instance.
+     *
+     * @return a new instance, equivalent to this one
+     */
     @Override
     public Matrix3d clone() {
         return new Matrix3d(m00, m01, m02,  
@@ -408,6 +413,15 @@ public class Matrix3d implements Cloneable, java.io.Serializable {
         return this;
     }
 
+    /**
+     * Tests for exact equality with the argument, distinguishing -0 from 0. If
+     * {@code o} is null, false is returned. Either way, the current instance is
+     * unaffected.
+     *
+     * @param o the object to compare (may be null, unaffected)
+     * @return true if {@code this} and {@code o} have identical values,
+     * otherwise false
+     */
     @Override
     public boolean equals( Object o ) {
         if( o == this )
@@ -438,6 +452,12 @@ public class Matrix3d implements Cloneable, java.io.Serializable {
         return true;
     }
 
+    /**
+     * Returns a hash code. If two matrices have identical values, they
+     * will have the same hash code. The matrix is unaffected.
+     *
+     * @return a 32-bit value for use in hashing
+     */
     @Override
     public int hashCode() {
         long bits = Double.doubleToLongBits(m00);
@@ -453,6 +473,15 @@ public class Matrix3d implements Cloneable, java.io.Serializable {
         return ((int)bits) ^ ((int)(bits >> 32));
     }
 
+    /**
+     * Returns a string representation of the matrix, which is unaffected. For
+     * example, an identity matrix would be represented by:
+     * <pre>
+     * Matrix3d[{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}]
+     * </pre>
+     *
+     * @return a descriptive string of text (not null, not empty)
+     */
     @Override
     public String toString() {
         return "Matrix3d[{" + m00 + ", " + m01 + ", " + m02 + "}, {"

--- a/src/main/java/com/simsilica/mathd/Quatd.java
+++ b/src/main/java/com/simsilica/mathd/Quatd.java
@@ -118,6 +118,11 @@ public final class Quatd implements Cloneable, java.io.Serializable {
         this.w = quat.getW();
     }
 
+    /**
+     * Creates a copy. The current instance is unaffected.
+     *
+     * @return a new instance, equivalent to this one
+     */
     @Override
     public final Quatd clone() {
         return new Quatd(x,y,z,w);
@@ -133,6 +138,12 @@ public final class Quatd implements Cloneable, java.io.Serializable {
         return new Quaternion((float)x, (float)y, (float)z, (float)w);
     }
 
+    /**
+     * Returns a hash code. If two quaternions have identical values, they
+     * will have the same hash code. The current instance is unaffected.
+     *
+     * @return a 32-bit value for use in hashing
+     */
     @Override
     public int hashCode() {
         long bits = Double.doubleToLongBits(x);
@@ -143,6 +154,15 @@ public final class Quatd implements Cloneable, java.io.Serializable {
         return ((int)bits) ^ ((int)(bits >> 32));
     }
 
+    /**
+     * Tests for exact equality with the argument, distinguishing -0 from 0. If
+     * {@code o} is null, false is returned. Either way, the current instance is
+     * unaffected.
+     *
+     * @param o the object to compare (may be null, unaffected)
+     * @return true if {@code this} and {@code o} have identical values,
+     *     otherwise false
+     */
     @Override
     public boolean equals( Object o ) {
         if( o == this )
@@ -781,6 +801,15 @@ public final class Quatd implements Cloneable, java.io.Serializable {
         return this;
     }
 
+    /**
+     * Returns a string representation of the quaternion, which is unaffected.
+     * For example, the identity quaternion is represented by:
+     * <pre>
+     * Quatd[0.0, 0.0, 0.0, 1.0]
+     * </pre>
+     *
+     * @return the string representation (not null, not empty)
+     */
     @Override
     public String toString() {
         return "Quatd[" + x + ", " + y + ", " + z + ", " + w + "]";

--- a/src/main/java/com/simsilica/mathd/Vec3d.java
+++ b/src/main/java/com/simsilica/mathd/Vec3d.java
@@ -142,6 +142,12 @@ public class Vec3d implements Cloneable, java.io.Serializable {
         return Double.isNaN(x) || Double.isNaN(y) || Double.isNaN(z);
     }
  
+    /**
+     * Returns a hash code. If two vectors have identical values, they will
+     * have the same hash code. The current instance is unaffected.
+     *
+     * @return a 32-bit value for use in hashing
+     */
     @Override
     public int hashCode() {
         long bits = Double.doubleToLongBits(x);
@@ -151,6 +157,15 @@ public class Vec3d implements Cloneable, java.io.Serializable {
         return ((int)bits) ^ ((int)(bits >> 32));
     }
     
+    /**
+     * Tests for exact equality with the argument, distinguishing -0 from 0. If
+     * {@code o} is null, false is returned. Either way, the current instance is
+     * unaffected.
+     *
+     * @param o the object to compare (may be null, unaffected)
+     * @return true if {@code this} and {@code o} have identical values,
+     *     otherwise false
+     */
     @Override
     public boolean equals( Object o ) {
         if( o == this )
@@ -281,6 +296,11 @@ public class Vec3d implements Cloneable, java.io.Serializable {
         return new Vec3i((int)Math.ceil(x), (int)Math.ceil(y), (int)Math.ceil(z));
     }
  
+    /**
+     * Creates a copy. The current instance is unaffected.
+     *
+     * @return a new instance, equivalent to the current one
+     */
     @Override
     public final Vec3d clone() {
         return new Vec3d(x,y,z);
@@ -750,6 +770,15 @@ public class Vec3d implements Cloneable, java.io.Serializable {
         return new Vec3d(x, z, y);
     }
     
+    /**
+     * Returns a string representation of the vector, which is unaffected.
+     * For example, the +X direction vector is represented by:
+     * <pre>
+     * Vec3d[1.0, 0.0, 0.0]
+     * </pre>
+     *
+     * @return the string representation (not null, not empty)
+     */
     @Override
     public String toString() {
         return "Vec3d[" + x + ", " + y + ", " + z + "]";


### PR DESCRIPTION
This PR adds javadoc for  the `clone()`, `equals()`, `hashCode()`, and `toString()` methods of `Matrix3d`, `Quatd` and `Vector3d`.

I left this for last because I realize many developers believe such methods don't need documentation. YMMV